### PR TITLE
Add Travis continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: java
+jdk: oraclejdk8
+branches:
+  only:
+  - master
+  - "/.*-[0-9]+\\..*/"
+install: true
+script: ".travis/build.sh"
+cache:
+  directories:
+  - "~/.m2/repository"

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+curl -fsLO https://raw.githubusercontent.com/scijava/scijava-scripts/master/travis-build.sh
+sh travis-build.sh

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![](https://travis-ci.org/NicoKiaru/LimeSeg.svg?branch=master)](https://travis-ci.org/NicoKiaru/LimeSeg)
+
 LimeSeg
 =========
 


### PR DESCRIPTION
This PR adds support for continuous integration using Travis CI. It requires that you activate this reposiory with https://travis-ci.org/.

With travis configured, new releases of *LimeSeg* can be automatically added to the ImageJ Maven repository and be used as dependencies in other project.

(The commits in this PR were created using [`travisify.sh`](https://github.com/scijava/scijava-scripts/blob/148638059be8436cfc16805e8f1cc147a4f60816/travisify.sh).)