### PR TITLE
Bump to SNAPSHOT version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-jdk: oraclejdk8
+jdk: openjdk8
 branches:
   only:
   - master

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
 	<groupId>eu.kiaru</groupId>
 	<artifactId>limeseg</artifactId>
-	<version>0.4.0</version>
+	<version>0.4.1-SNAPSHOT</version>
 
 	<name>limeseg</name>
 	<url>http://</url>


### PR DESCRIPTION
To ensure software reproducibility, release versions uploaded to maven.imagej.net *must* be unique (e.g. version `0.4.0` cannot be uploaded a second time).
To achieve this goal of reproducible release versions, these should be created using [`release-version.sh`](https://github.com/scijava/scijava-scripts/blob/master/release-version.sh) from `scijava/scijava-scripts`, and the master branch should always be on a `SNAPSHOT` version.